### PR TITLE
Move product dependency closer to declaration

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -277,6 +277,10 @@ macro(ssg_build_ansible_playbooks PRODUCT)
         DEPENDS "${SSG_BUILD_SCRIPTS}/build_rule_playbooks.py"
         COMMENT "[${PRODUCT}-content] Generating Ansible Playbooks"
     )
+    add_custom_target(
+        generate-${PRODUCT}-ansible-playbooks
+        DEPENDS "${ANSIBLE_PLAYBOOKS_DIR}"
+    )
     add_test(
         NAME "${PRODUCT}-ansible-playbooks-generated-for-all-rules"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/ansible_playbooks_generated_for_all_rules.py" --build-dir "${CMAKE_BINARY_DIR}" --product "${PRODUCT}"
@@ -766,12 +770,12 @@ macro(ssg_build_product PRODUCT)
     ssg_build_ocil_unlinked(${PRODUCT})
     ssg_build_remediations(${PRODUCT})
 
-    add_custom_target(
-        generate-${PRODUCT}-ansible-playbooks
-        DEPENDS "${ANSIBLE_PLAYBOOKS_DIR}"
-    )
     if ("${PRODUCT_ANSIBLE_REMEDIATION_ENABLED}" AND SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED)
         ssg_build_ansible_playbooks(${PRODUCT})
+        add_dependencies(
+            ${PRODUCT}-content
+            generate-${PRODUCT}-ansible-playbooks
+        )
     endif()
     ssg_build_xccdf_with_remediations(${PRODUCT})
     ssg_build_oval_unlinked(${PRODUCT})
@@ -802,10 +806,6 @@ macro(ssg_build_product PRODUCT)
     add_dependencies(zipfile "generate-ssg-${PRODUCT}-ds.xml")
 
     if ("${PRODUCT_ANSIBLE_REMEDIATION_ENABLED}" AND SSG_ANSIBLE_PLAYBOOKS_ENABLED)
-        add_dependencies(
-            ${PRODUCT}-content
-            generate-${PRODUCT}-ansible-playbooks
-        )
         ssg_build_profile_playbooks(${PRODUCT})
         add_custom_target(
             ${PRODUCT}-profile-playbooks


### PR DESCRIPTION


#### Description:

- Relocate declaration of dependency of ` ${PRODUCT}-content` over target `generate-${PRODUCT}-ansible-playbooks`.

#### Rationale:

A dependency on rule playbooks target was being added from a conditional branch related to profile playbooks.
It caused issues when building profile playbooks but not rule playbooks,
the rule playbooks target would not exist, but still be added as dependency.

Tested with and without `SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED`:
```
cd build
cmake -G Ninja -DSSG_PRODUCT_DEFAULT:BOOLEAN=OFF -DSSG_PRODUCT_RHEL8:BOOLEAN=ON -DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOLEAN=ON -DCMAKE_INSTALL_PREFIX=/tmp ../ && ninja-build -j 32 > content.log
ninja install
```